### PR TITLE
add battery levels and 2 rain meters: mm/hour, cumulated today

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,18 @@ This app supports multiple NetAtmo devices on Homey. Support includes:
 
 - NetAtmo Weather Station + modules
     - Read sensors
+        * Battery Level
         * Temperature
         * Humidity
-        * CO2
-        * Pressure
+        * CO2 (Carbon Dioxide)
+        * Atmospheric Pressure
         * Noise
-        * Rain
+        * Rain (now, mm/hour, cumulated today)
         * Humidity
-        * WindStrength
-        * WindAngle
-        * GustStrength
-        * GustAngle
+        * Wind Strength
+        * Wind Angle
+        * Gust Strength
+        * Gust Angle
 - NetAtmo Thermostat
     - Read sensors
         * Temperature
@@ -24,6 +25,21 @@ This app supports multiple NetAtmo devices on Homey. Support includes:
         * Active Program
         * Active Mode
 
-Support to be added:
+**Note:**
+There will be 3 "Rain" global tokens until that [issue](https://github.com/athombv/homey/issues/1588) is fixed.  
+For now, the order is always the same:  
+* Top Rain: Rain now
+* Middle Rain: mm/hour
+* Bottom Rain: Cummulated today
 
-- NetAtmo Welcome
+Support to be added:
+- NetAtmo Welcome:
+    * NetAtmo Tags
+    * NetAtmo Smart Smoke Alarm
+- NetAtmo Presence
+- NetAtmo Healthy Home Coach
+
+### Changelog:
+- 2.0.6: (re-pair is needed for the extra capabilities)
+    * Added battery levels
+    * Added rain: mm/hour and 24h accumulated

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ There will be 3 "Rain" global tokens until that [issue](https://github.com/athom
 For now, the order is always the same:  
 * Top Rain: Rain now
 * Middle Rain: mm/hour
-* Bottom Rain: Cummulated today
+* Bottom Rain: Cumulated today
 
 Support to be added:
 - NetAtmo Welcome:

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
 	"id": "com.netatmo",
-	"version": "2.0.5",
+	"version": "2.0.6",
 	"compatibility": ">=0.8.30",
 	"category": "climate",
 	"name": {
@@ -19,6 +19,10 @@
 				"name": "Marco Frijmann",
 				"website": "http://www.frijmann.nl",
 				"email": "marco@frijmann.nl"
+			},
+			{
+				"name": "Remco Mengers",
+				"email": "caseda08@hotmail.com"
 			}
 		]
 	},
@@ -39,17 +43,40 @@
 			},
 			"class": "sensor",
 			"capabilities": [
+				"measure_battery",
 				"measure_temperature",
 				"measure_co2",
 				"measure_humidity",
 				"measure_pressure",
 				"measure_noise",
-				"measure_rain",
+				"measure_rain.now",
+				"measure_rain.1h",
+				"measure_rain.24h",
 				"measure_wind_strength",
 				"measure_wind_angle",
 				"measure_gust_strength",
 				"measure_gust_angle"
 			],
+			"capabilitiesOptions": {
+				"measure_rain.now": {
+					"title": {
+						"en": "Rain now",
+						"nl": "Regen nu"
+					}
+				},
+				"measure_rain.1h": {
+					"title": {
+						"en": "mm/hour",
+						"nl": "mm/uur"
+					}
+				},
+				"measure_rain.24h": {
+					"title": {
+						"en": "Today",
+						"nl": "Vandaag"
+					}
+				}
+    	},
 			"pair": [
 				{
 					"id": "start"
@@ -169,6 +196,82 @@
 							"en": "My Program",
 							"nl": "Mijn Programma"
 						}
+					}
+				]
+			}
+		],
+		"triggers": [
+			{
+				"id": "rain_now_changed",
+				"title": {
+					"en": "The rain (now) has changed",
+					"nl": "De regen (nu) is veranderd"
+				},
+				"tokens": [
+					{
+						"name": "rain",
+						"type": "number",
+						"title": {
+							"en": "Rain",
+							"en": "Regen"
+						},
+						"example": 1
+					}
+				],
+				"args": [
+					{
+						"name": "device",
+						"type": "device",
+						"filter": "driver_id=weatherstation&capabilities=measure_rain.now"
+					}
+				]
+			},
+			{
+				"id": "rain_hour_changed",
+				"title": {
+					"en": "The rain/hour has changed",
+					"nl": "De regen/uur is veranderd"
+				},
+				"tokens": [
+					{
+						"name": "hour",
+						"type": "number",
+						"title": {
+							"en": "mm/h",
+							"nl": "mm/u"
+						},
+						"example": 3
+					}
+				],
+				"args": [
+					{
+						"name": "device",
+						"type": "device",
+						"filter": "driver_id=weatherstation&capabilities=measure_rain.1h"
+					}
+				]
+			},
+			{
+				"id": "rain_day_changed",
+				"title": {
+					"en": "The cumulated rain has changed",
+					"nl": "De gecumuleerde regen is veranderd"
+				},
+				"tokens": [
+					{
+						"name": "today",
+						"type": "number",
+						"title": {
+							"en": "mm"
+						},
+						"example": 5
+					}
+				],
+				"args": [
+					{
+						"name": "device",
+						"type": "device",
+						"filter": "driver_id=weatherstation&capabilities=measure_rain.24h"
 					}
 				]
 			}

--- a/app.json
+++ b/app.json
@@ -213,7 +213,7 @@
 						"type": "number",
 						"title": {
 							"en": "Rain",
-							"en": "Regen"
+							"nl": "Regen"
 						},
 						"example": 1
 					}

--- a/drivers/weatherstation/driver.js
+++ b/drivers/weatherstation/driver.js
@@ -4,6 +4,10 @@ const deviceMap = new Map();
 const state = new Map();
 
 const CAPABILITY_MAP = {
+	battery: [{
+		id: 'measure_battery',
+		location: 'battery_percent',
+	}],
 	temperature: [{
 		id: 'measure_temperature',
 		location: 'dashboard_data.Temperature',
@@ -24,10 +28,20 @@ const CAPABILITY_MAP = {
 		id: 'measure_noise',
 		location: 'dashboard_data.Noise',
 	}],
-	rain: [{
-		id: 'measure_rain',
-		location: 'dashboard_data.Rain',
-	}],
+	rain: [
+		{
+			id: 'measure_rain.now',
+			location: 'dashboard_data.Rain',
+		},
+		{
+			id: 'measure_rain.1h',
+			location: 'dashboard_data.sum_rain_1',
+		},
+		{
+			id: 'measure_rain.24h',
+			location: 'dashboard_data.sum_rain_24',
+		}
+	],
 	wind: [
 		{
 			id: 'measure_wind_strength',
@@ -151,6 +165,10 @@ module.exports = {
 
 							const capabilities = [];
 
+							if (module.battery_percent) {
+								capabilities.push('measure_battery');
+							}
+
 							module.data_type.forEach(dataTypeItem => {
 								if (CAPABILITY_MAP[dataTypeItem.toLowerCase()]) {
 									CAPABILITY_MAP[dataTypeItem.toLowerCase()].forEach(capability => {
@@ -230,6 +248,13 @@ function getState(capability, deviceInfo, callback) {
 }
 
 function updateState(device, newState) {
+	if (newState.hasOwnProperty('battery_percent')) {
+		const value = newState['battery_percent'];
+		if (value && state.get(device.id).get('measure_battery') !== value) {
+			state.get(device.id).set('measure_battery', value);
+			module.exports.realtime(deviceMap.get(device.id), 'measure_battery', value);
+		}
+	}
 	newState.data_type.forEach(dataType => {
 		CAPABILITY_MAP[dataType.toLowerCase()].forEach(capability => {
 			const value = capability.location.split('.').reduce(
@@ -237,6 +262,9 @@ function updateState(device, newState) {
 				newState
 			);
 			if (!value._notFound && state.get(device.id).get(capability.id) !== value) {
+				if (capability.id === 'measure_rain.now') Homey.manager('flow').triggerDevice('rain_now_changed', { rain: value }, null, deviceMap.get(device.id));
+				if (capability.id === 'measure_rain.1h') Homey.manager('flow').triggerDevice('rain_hour_changed', { hour: value }, null, deviceMap.get(device.id));
+				if (capability.id === 'measure_rain.24h') Homey.manager('flow').triggerDevice('rain_today_changed', { today: value }, null, deviceMap.get(device.id));
 				state.get(device.id).set(capability.id, value);
 				module.exports.realtime(deviceMap.get(device.id), capability.id, value);
 			}
@@ -315,4 +343,3 @@ Object.keys(CAPABILITY_MAP).forEach(type => {
 
 module.exports.refreshState = refreshState;
 module.exports.refreshAccountState = refreshAccountState;
-


### PR DESCRIPTION
There will be 3 "Rain" global tokens until that [issue](https://github.com/athombv/homey/issues/1588) is fixed.
For now, the order is always the same:
* Top Rain: Rain now
* Middle Rain: mm/hour
* Bottom Rain: Cummulated today

Have added a note in the Readme about it.. But they will probably not read it 😂...
Could wait for that fix, but since it is only visual glitch, and don't know when it will be fixed... I just submitted it anyway

This will fix issue #16 though