### PR TITLE
fix cumulated rain not triggering

### DIFF
--- a/app.json
+++ b/app.json
@@ -222,7 +222,7 @@
 					{
 						"name": "device",
 						"type": "device",
-						"filter": "driver_id=weatherstation&capabilities=measure_rain.now"
+						"filter": "driver_id=weatherstation&capabilities=measure_rain"
 					}
 				]
 			},

--- a/drivers/weatherstation/driver.js
+++ b/drivers/weatherstation/driver.js
@@ -262,9 +262,11 @@ function updateState(device, newState) {
 				newState
 			);
 			if (!value._notFound && state.get(device.id).get(capability.id) !== value) {
-				if (capability.id === 'measure_rain') Homey.manager('flow').triggerDevice('rain_now_changed', { rain: value }, null, deviceMap.get(device.id));
-				if (capability.id === 'measure_rain.1h') Homey.manager('flow').triggerDevice('rain_hour_changed', { hour: value }, null, deviceMap.get(device.id));
-				if (capability.id === 'measure_rain.24h') Homey.manager('flow').triggerDevice('rain_today_changed', { today: value }, null, deviceMap.get(device.id));
+				if (typeof state.get(device.id).get(capability.id) !== 'undefined') {
+					if (capability.id === 'measure_rain') Homey.manager('flow').triggerDevice('rain_now_changed', { rain: Math.round(value * 100) / 100 }, null, deviceMap.get(device.id));
+					if (capability.id === 'measure_rain.1h') Homey.manager('flow').triggerDevice('rain_hour_changed', { hour: Math.round(value * 100) / 100 }, null, deviceMap.get(device.id));
+					if (capability.id === 'measure_rain.24h') Homey.manager('flow').triggerDevice('rain_day_changed', { today: Math.round(value * 100) / 100 }, null, deviceMap.get(device.id));
+				}
 				state.get(device.id).set(capability.id, value);
 				self.realtime(deviceMap.get(device.id), capability.id, value);
 			}


### PR DESCRIPTION
the filter still needed to change from the sub capability (for rain now) to what you did to the rest.
even though it still shows up? i guess the filter doesn't take sub capabilities into consideration. (future proofing if ever changed)

The trigger id was not right for the cumulated rain.
Changed the ids around when working on the driver, so i guess i missed it in 1 place, fixed it now.
Also added a check so the flows won't trigger when the value was undefined before hand (on start up of the app), so now it won't trigger on app start-up

And rounded the trigger tokens to 2 decimals, so it is the same as the capability (global tokens)